### PR TITLE
Fix ctrl-drag not working in Foundry V12

### DIFF
--- a/token-animation-tools.js
+++ b/token-animation-tools.js
@@ -265,8 +265,9 @@ Hooks.once('ready', () => {
 		if(!e)
 			return;
 
-		if(e[keyVar] && ('x' in diff || 'y' in diff) && !('concludeAnimations' in options)) {
+		if(e[keyVar] && ('x' in diff || 'y' in diff) && !('concludeAnimations' in options) && !('animate' in options)) {
 			options.concludeAnimations = true;
+			options.animate = false;
 		}
 	});
 });


### PR DESCRIPTION
The concludeAnimations option has been changed to animate in Foundry V12, so this patch just adds both to support both version 12 and previous versions